### PR TITLE
Rebuild: neon-glass PWA for GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Build & Deploy (Text-only)
+name: Build & Deploy (GitHub Pages)
 
 on:
   push:
@@ -27,7 +27,7 @@ jobs:
           cache: "npm"
       - name: Install
         run: npm ci
-      - name: Generate icons from SVG (text-only → PNG at build time)
+      - name: Generate icons from SVG
         run: npm run gen:icons
       - name: Build
         run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ dist
 .DS_Store
 public/icons/icon-192.png
 public/icons/icon-512.png
-.astro

--- a/.nojekyll
+++ b/.nojekyll
@@ -1,0 +1,1 @@
+# Prevent GitHub from invoking Jekyll

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
-# Portal PWA (Text-only repo)
-- Installable PWA on GitHub Pages
-- Local-only Diary (IndexedDB/Dexie)
-- No committed binaries: PNG icons generated in CI from SVG
-- Mobile-first Tailwind UI
+# Portal (GitHub Pages PWA)
+Sexy, installable PWA with neon gradients, glassmorphism, and buttery motion. Local-only Diary (IndexedDB).
 
 ## Dev
 npm install
@@ -12,4 +9,4 @@ npm run dev
 npm run build
 
 ## Deploy
-Push to `main` → GitHub Actions builds & deploys to Pages.
+Push to `main`. Ensure **Settings → Pages → Source = GitHub Actions**.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,14 +12,14 @@ export default defineConfig({
       registerType: "autoUpdate",
       includeAssets: ["icons/icon-maskable.svg"],
       manifest: {
-        name: "Portal PWA",
+        name: "Portal",
         short_name: "Portal",
-        description: "Offline-capable portal with a local diary.",
+        description: "A sexy, offline-capable portal with a local diary & tools.",
         start_url: ".",
         scope: ".",
         display: "standalone",
-        background_color: "#0a0a0a",
-        theme_color: "#0ea5e9",
+        background_color: "#070B12",
+        theme_color: "#22d3ee",
         icons: [
           { src: "icons/icon-192.png", sizes: "192x192", type: "image/png", purpose: "any maskable" },
           { src: "icons/icon-512.png", sizes: "512x512", type: "image/png", purpose: "any maskable" }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "portal-pwa-textonly",
-  "version": "0.1.0",
+  "name": "yaron-portal-pwa",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "portal-pwa-textonly",
-      "version": "0.1.0",
+      "name": "yaron-portal-pwa",
+      "version": "1.0.0",
       "dependencies": {
         "@astrojs/react": "^4.3.0",
         "@astrojs/tailwind": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "portal-pwa-textonly",
-  "version": "0.1.0",
+  "name": "yaron-portal-pwa",
+  "version": "1.0.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/public/icons/icon-maskable.svg
+++ b/public/icons/icon-maskable.svg
@@ -1,14 +1,14 @@
-<!-- Single SVG source used to generate all PNGs in CI (text-only asset) -->
+<!-- One SVG source -> CI generates PNGs; no binaries tracked -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
   <defs>
     <linearGradient id="g" x1="0" x2="1" y1="0" y2="1">
-      <stop offset="0%" stop-color="#06b6d4"/>
-      <stop offset="100%" stop-color="#0ea5e9"/>
+      <stop offset="0%" stop-color="#22d3ee"/>
+      <stop offset="100%" stop-color="#a78bfa"/>
     </linearGradient>
   </defs>
   <rect width="512" height="512" rx="96" fill="url(#g)"/>
   <g fill="white">
-    <circle cx="256" cy="200" r="72" />
-    <path d="M128 352c0-53 53-96 128-96s128 43 128 96v32H128z"/>
+    <circle cx="256" cy="196" r="68"/>
+    <path d="M128 352c0-50 53-92 128-92s128 42 128 92v32H128z"/>
   </g>
 </svg>

--- a/scripts/gen-icons.mjs
+++ b/scripts/gen-icons.mjs
@@ -1,27 +1,18 @@
-/**
- * Generate PNG icons (not committed) from the SVG source.
- * Outputs to public/icons/icon-192.png and icon-512.png before build.
- * Requires 'sharp' which runs in CI and locally if needed.
- */
 import fs from "node:fs/promises";
 import path from "node:path";
 import sharp from "sharp";
-
 const svgPath = path.resolve("public/icons/icon-maskable.svg");
 const outDir = path.resolve("public/icons");
-
 const sizes = [192, 512];
-
-const ensure = async (p) => fs.mkdir(p, { recursive: true }).catch(()=>{});
+const ensure = async p => fs.mkdir(p, { recursive: true }).catch(()=>{});
 const run = async () => {
   await ensure(outDir);
   const svg = await fs.readFile(svgPath);
-  await Promise.all(sizes.map(async (s) => {
+  await Promise.all(sizes.map(async s => {
     const pngPath = path.join(outDir, `icon-${s}.png`);
     const buf = await sharp(svg).resize(s, s, { fit: "cover" }).png().toBuffer();
     await fs.writeFile(pngPath, buf);
     console.log("Generated", pngPath);
   }));
 };
-
-run().catch((e) => { console.error(e); process.exit(1); });
+run().catch(e => { console.error(e); process.exit(1); });

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,0 +1,15 @@
+---
+const tabs = [
+  { href: "./", label: "Home", icon: "🏠" },
+  { href: "./diary", label: "Diary", icon: "📝" },
+  { href: "./tools", label: "Tools", icon: "🧰" },
+  { href: "./about", label: "About", icon: "✨" }
+];
+---
+<nav class="fixed bottom-4 left-1/2 -translate-x-1/2 z-50">
+  <div class="flex gap-2 bg-white/10 backdrop-blur-lg border border-white/15 rounded-3xl p-2 shadow-soft">
+    {tabs.map(t => (
+      <a href={t.href} class="px-4 py-2 rounded-2xl bg-white/5 hover:bg-white/10 text-sm">{t.icon} {t.label}</a>
+    ))}
+  </div>
+</nav>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,47 +1,61 @@
 ---
-const { title = "Portal", description = "Offline-capable portal with a local diary." } = Astro.props;
+const { title = "Portal", description = "A sexy, offline-capable portal with a local diary & tools." } = Astro.props;
+import Nav from "../components/Nav.astro";
+const base = import.meta.env.BASE_URL;
 ---
 <!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#0ea5e9" />
+    <meta name="theme-color" content="#22d3ee" />
     <title>{title}</title>
     <meta name="description" content={description} />
-    <link rel="manifest" href="/manifest.webmanifest" />
-    <link rel="icon" href="/icons/icon-maskable.svg" type="image/svg+xml" />
-    <link rel="apple-touch-icon" href="/icons/icon-maskable.svg" />
-    <link rel="stylesheet" href="/src/styles/global.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Poppins:wght@600;800&display=swap" rel="stylesheet" />
+    <link rel="manifest" href={base + "manifest.webmanifest"} />
+    <link rel="icon" href={base + "icons/icon-maskable.svg"} type="image/svg+xml" />
+    <link rel="apple-touch-icon" href={base + "icons/icon-maskable.svg"} />
+    <link rel="stylesheet" href={base + "src/styles/global.css"} />
   </head>
-  <body>
+  <body class="font-body">
+    <!-- Floating neon blobs -->
+    <div class="pointer-events-none fixed inset-0 -z-10">
+      <div class="blob absolute top-[-10%] left-[5%] w-[45vw] h-[45vw] rounded-full bg-neon-cyan animate-floaty"></div>
+      <div class="blob absolute top-[0%] right-[5%] w-[35vw] h-[35vw] rounded-full bg-neon-purple animate-floaty" style="animation-delay: -2s"></div>
+      <div class="blob absolute bottom-[-10%] left-[30%] w-[40vw] h-[40vw] rounded-full bg-neon-pink animate-floaty" style="animation-delay: -4s"></div>
+    </div>
+
     <header class="container py-6">
       <nav class="flex items-center justify-between">
-        <a href="./" class="text-xl font-bold tracking-tight">Portal</a>
+        <a href="./" class="text-2xl md:text-3xl font-display font-extrabold tracking-tight drop-shadow-[0_2px_20px_rgba(34,211,238,.35)]">Portal</a>
         <div class="flex items-center gap-2">
-          <a href="./" class="btn-ghost text-sm">Home</a>
           <a href="./diary" class="btn-ghost text-sm">Diary</a>
+          <a href="./tools" class="btn-ghost text-sm">Tools</a>
+          <a href="./about" class="btn-ghost text-sm">About</a>
         </div>
       </nav>
     </header>
-    <main class="container pb-24">
+
+    <main class="container pb-28">
       <slot />
     </main>
+
+    <Nav />
+
     <footer class="container py-10 text-center text-muted">
-      <p>Offline PWA • Text-only repo • Icons generated in CI</p>
+      <p>Installable PWA • Offline • Text-only repo (icons generated in CI)</p>
     </footer>
 
     <script type="module">
+      // PWA update toast
       if ("serviceWorker" in navigator) {
         navigator.serviceWorker.addEventListener("controllerchange", () => {
           const bar = document.createElement("div");
-          bar.textContent = "App updated. Tap to reload.";
-          Object.assign(bar.style, {
-            position: "fixed", inset: "auto 1rem 1rem 1rem",
-            background: "#0ea5e9", color: "#0b1220", padding: "0.75rem 1rem",
-            borderRadius: "0.75rem", fontWeight: "700", textAlign: "center", zIndex: "9999",
-            boxShadow: "0 10px 30px rgba(0,0,0,.2)", cursor: "pointer"
-          });
+          bar.textContent = "Updated. Tap to reload.";
+          Object.assign(bar.style, { position: "fixed", inset: "auto 1rem 1rem 1rem", background:"#22d3ee", color:"#06131a",
+            padding:"0.8rem 1rem", borderRadius:"1rem", fontWeight:"700", textAlign:"center", zIndex:"9999", boxShadow:"0 10px 30px rgba(0,0,0,.3)", cursor:"pointer" });
           bar.onclick = () => location.reload();
           document.body.appendChild(bar);
         });

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,4 +1,5 @@
 import Dexie, { type Table } from "dexie";
 export interface Entry { id?: number; createdAt: number; updatedAt: number; title: string; body: string; tags: string[]; }
-class DiaryDB extends Dexie { entries!: Table<Entry, number>; constructor() { super("portal-diary"); this.version(1).stores({ entries: "++id, createdAt, updatedAt, title" }); } }
+class DiaryDB extends Dexie { entries!: Table<Entry, number>;
+  constructor(){ super("portal-diary"); this.version(1).stores({ entries: "++id, createdAt, updatedAt, title" }); } }
 export const db = new DiaryDB();

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,0 +1,16 @@
+---
+import Base from "../layouts/Base.astro";
+---
+<Base title="Portal • About">
+  <section class="grid gap-6">
+    <div class="card p-6 animate-fadeUp">
+      <h1 class="text-2xl font-display font-extrabold mb-2">About</h1>
+      <p class="text-muted">This PWA is hosted on GitHub Pages, works offline, and keeps the repo text-only by generating icons in CI.</p>
+      <ul class="list-disc pl-6 mt-3 text-muted space-y-1">
+        <li>Astro + Tailwind + VitePWA</li>
+        <li>Neon gradient aesthetic, glass cards, micro-interactions</li>
+        <li>Local Diary (IndexedDB). No external backend.</li>
+      </ul>
+    </div>
+  </section>
+</Base>

--- a/src/pages/diary.astro
+++ b/src/pages/diary.astro
@@ -2,11 +2,11 @@
 import Base from "../layouts/Base.astro";
 import DiaryApp from "../ui/DiaryApp.jsx";
 ---
-<Base title="Portal • Diary" description="Offline local diary with search, tags, and backups.">
+<Base title="Portal • Diary" description="Offline local diary with search, tags, backups.">
   <section class="grid gap-6">
-    <div class="card p-5 animate-fadeInUp">
-      <h1 class="text-2xl font-bold mb-1">Diary</h1>
-      <p class="text-muted">Data is stored locally on this device. Use Export/Import to move between devices.</p>
+    <div class="card p-5 animate-fadeUp">
+      <h1 class="text-2xl font-display font-extrabold mb-1">Diary</h1>
+      <p class="text-muted">Saved locally on this device. Export/Import JSON to move between devices.</p>
     </div>
     <DiaryApp client:load />
   </section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,22 +3,29 @@ import Base from "../layouts/Base.astro";
 ---
 <Base title="Portal • Home">
   <section class="grid gap-6">
-    <div class="card p-6 animate-fadeInUp">
-      <h1 class="text-3xl font-bold mb-2">Welcome 👋</h1>
-      <p class="text-muted">Installable PWA hosted on GitHub Pages. Local diary, offline-first, no committed binaries.</p>
-      <div class="mt-6 flex gap-3">
-        <a href="./diary" class="btn-primary">Open Diary</a>
+    <div class="card p-7 animate-fadeUp">
+      <h1 class="text-4xl font-display font-extrabold mb-2 leading-tight">Your personal <span class="text-neon-cyan">Portal</span></h1>
+      <p class="text-muted">Gorgeous, fast, installable. Built for offline use with buttery motion and a privacy-friendly local diary.</p>
+      <div class="mt-6 flex flex-wrap gap-3">
+        <a href="./diary" class="btn-primary animate-pulseGlow">Open Diary</a>
+        <a href="./tools" class="btn-ghost">Open Tools</a>
         <button id="installBtn" class="btn-ghost" style="display:none">Install App</button>
       </div>
     </div>
 
-    <div class="card p-6 animate-fadeInUp" style="animation-delay:120ms">
-      <h2 class="text-xl font-semibold mb-2">How this stays text-only</h2>
-      <ul class="list-disc pl-6 text-muted space-y-1">
-        <li>SVG icon is stored in repo</li>
-        <li>CI generates PNG icons from SVG before build</li>
-        <li>No images or binaries committed</li>
-      </ul>
+    <div class="grid md:grid-cols-3 gap-4">
+      <div class="card p-5 animate-fadeUp" style="animation-delay:80ms">
+        <h3 class="font-semibold mb-1">Offline-first</h3>
+        <p class="text-sm text-muted">Works without internet. Your data stays on this device unless you export it.</p>
+      </div>
+      <div class="card p-5 animate-fadeUp" style="animation-delay:140ms">
+        <h3 class="font-semibold mb-1">Installable</h3>
+        <p class="text-sm text-muted">Add to Home Screen on Android for a native-like experience.</p>
+      </div>
+      <div class="card p-5 animate-fadeUp" style="animation-delay:200ms">
+        <h3 class="font-semibold mb-1">Text-only repo</h3>
+        <p class="text-sm text-muted">No binaries tracked. Icons are generated in CI from a single SVG.</p>
+      </div>
     </div>
   </section>
 

--- a/src/pages/tools.astro
+++ b/src/pages/tools.astro
@@ -1,0 +1,29 @@
+---
+import Base from "../layouts/Base.astro";
+---
+<Base title="Portal • Tools">
+  <section class="grid gap-6">
+    <div class="card p-6 animate-fadeUp">
+      <h2 class="text-xl font-semibold mb-3">Quick Tools</h2>
+      <div class="grid md:grid-cols-2 gap-4">
+        <div class="card p-4">
+          <h3 class="font-semibold mb-2">Word Counter</h3>
+          <textarea id="wc" class="input min-h-[24vh]" placeholder="Paste text…"></textarea>
+          <div class="mt-2 text-sm text-muted">Words: <span id="wcout">0</span> • Chars: <span id="ccout">0</span></div>
+        </div>
+        <div class="card p-4">
+          <h3 class="font-semibold mb-2">Unit: cm → inches</h3>
+          <input id="cm" class="input" placeholder="Enter cm…" />
+          <div class="mt-2 text-sm text-muted">Inches: <span id="inch">0</span></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <script>
+    const wc = document.getElementById('wc'), wcout = document.getElementById('wcout'), ccout = document.getElementById('ccout');
+    wc?.addEventListener('input', ()=>{ const t = wc.value || ""; wcout.textContent = (t.trim().match(/\S+/g)||[]).length; ccout.textContent = t.length; });
+    const cm = document.getElementById('cm'), inch = document.getElementById('inch');
+    cm?.addEventListener('input', ()=>{ const v = parseFloat(cm.value||"0"); inch.textContent = isNaN(v) ? "0" : (v/2.54).toFixed(2); });
+  </script>
+</Base>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,12 +3,22 @@
 @tailwind utilities;
 
 :root { color-scheme: light dark; }
+
 html, body { height: 100%; }
-body { @apply bg-neutral-950 text-neutral-100 antialiased; }
+body { @apply bg-[radial-gradient(1200px_600px_at_10%_-10%,#0ea5e9,transparent),radial-gradient(1000px_500px_at_90%_10%,#a78bfa,transparent),bg-base text-neutral-100 antialiased; }
+
 .container { @apply max-w-screen-md mx-auto px-4; }
-.card { @apply bg-neutral-900/70 backdrop-blur rounded-2xl shadow-soft border border-neutral-800; }
-.btn { @apply inline-flex items-center justify-center gap-2 rounded-xl px-4 py-2 font-semibold transition active:scale-95; }
-.btn-primary { @apply btn bg-brand-600 text-white hover:bg-cyan-500; }
-.btn-ghost { @apply btn bg-neutral-900 hover:bg-neutral-800 border border-neutral-800; }
-.input { @apply w-full rounded-xl bg-neutral-900 border border-neutral-800 px-3 py-2 outline-none focus:ring-2 focus:ring-brand-600; }
-.text-muted { @apply text-neutral-400; }
+
+.card { @apply bg-glass backdrop-blur-md rounded-3xl border border-white/10 shadow-soft; }
+
+.btn { @apply inline-flex items-center justify-center gap-2 rounded-2xl px-4 py-2 font-semibold transition active:scale-95; }
+.btn-primary { @apply btn bg-neon-cyan text-black hover:brightness-110 shadow-glow; }
+.btn-ghost { @apply btn bg-white/5 hover:bg-white/10 border border-white/10; }
+
+.input { @apply w-full rounded-2xl bg-white/5 border border-white/10 px-4 py-3 outline-none focus:ring-2 focus:ring-neon-cyan; }
+.text-muted { @apply text-neutral-300; }
+
+.blob {
+  filter: blur(40px);
+  opacity: .4;
+}

--- a/src/ui/DiaryApp.jsx
+++ b/src/ui/DiaryApp.jsx
@@ -10,7 +10,7 @@ export default function DiaryApp(){
 
   const refresh=async()=> setEntries(await db.entries.orderBy("createdAt").reverse().toArray());
   useEffect(()=>{refresh();},[]);
-  useEffect(()=>{const h=setTimeout(async()=>{ if(!title && !body) return; if(selectedId){ await db.entries.update(selectedId,{title,body,tags:toTags(tags),updatedAt:Date.now()}); refresh();}},500); return()=>clearTimeout(h);},[title,body,tags,selectedId]);
+  useEffect(()=>{const h=setTimeout(async()=>{ if(!title && !body) return; if(selectedId){ await db.entries.update(selectedId,{title,body,tags:toTags(tags),updatedAt:Date.now()}); refresh();}},450); return()=>clearTimeout(h);},[title,body,tags,selectedId]);
 
   async function createNew(){ const id=await db.entries.add({createdAt:Date.now(),updatedAt:Date.now(),title:title||"Untitled",body:body||"",tags:toTags(tags)}); setSelectedId(id); refresh(); }
   function selectEntry(e){ setSelectedId(e.id); setTitle(e.title); setBody(e.body); setTags((e.tags||[]).join(", ")); }
@@ -23,23 +23,22 @@ export default function DiaryApp(){
   return (
     <div className="grid gap-4 md:grid-cols-[280px_1fr]">
       <aside className="card p-4 h-max sticky top-4">
-        <input className="input mb-3" placeholder="Search…" value={q} onChange={e=>setQ(e.target.value)} />
+        <input className="input mb-2" placeholder="Search…" value={q} onChange={e=>setQ(e.target.value)} />
         <input className="input mb-3" placeholder="Filter by tag…" value={tagQ} onChange={e=>setTagQ(e.target.value)} />
-        <button className="btn-primary w-full" onClick={createNew}>New Entry</button>
-        <hr className="my-4 border-neutral-800" />
+        <button className="btn-primary w-full mb-4" onClick={createNew}>New Entry</button>
         <div className="max-h-[50vh] overflow-auto pr-1 space-y-2">
-          {filtered().map(e=> (
-            <button key={e.id} onClick={()=>selectEntry(e)} className={`w-full text-left p-3 rounded-xl border transition ${selectedId===e.id?"border-brand-600 bg-neutral-900":"border-neutral-800 hover:bg-neutral-900"}`}>
+          {filtered().map(e=>(
+            <button key={e.id} onClick={()=>selectEntry(e)} className={`w-full text-left p-3 rounded-2xl border transition ${selectedId===e.id?"border-white/30 bg-white/10":"border-white/10 hover:bg-white/5"}`}>
               <div className="font-semibold">{e.title||"Untitled"}</div>
-              <div className="text-muted text-sm">{fmt(e.updatedAt)}</div>
-              {e.tags?.length ? <div className="mt-1 text-xs text-neutral-400">#{e.tags.join(" #")}</div> : null}
+              <div className="text-muted text-xs">{fmt(e.updatedAt)}</div>
+              {e.tags?.length ? <div className="mt-1 text-xs text-neutral-300">#{e.tags.join(" #")}</div> : null}
             </button>
           ))}
           {!filtered().length && <div className="text-muted text-sm">No entries yet.</div>}
         </div>
       </aside>
 
-      <section className="card p-4 animate-fadeInUp">
+      <section className="card p-4 animate-fadeUp">
         <input className="input text-xl font-semibold mb-3" placeholder="Title…" value={title} onChange={e=>setTitle(e.target.value)} />
         <textarea className="input min-h-[40vh] mb-3" placeholder="Write your thoughts…" value={body} onChange={e=>setBody(e.target.value)} />
         <input className="input mb-3" placeholder="tags, comma,separated" value={tags} onChange={e=>setTags(e.target.value)} />
@@ -50,7 +49,7 @@ export default function DiaryApp(){
           <input ref={fileRef} type="file" accept="application/json" className="hidden" onChange={e=>e.target.files[0]&&importJSON(e.target.files[0])} />
           <button className="btn-ghost" onClick={()=>fileRef.current?.click()}>Import</button>
         </div>
-        <p className="text-xs text-neutral-500 mt-2">Autosaves every ~0.5s when editing an existing note.</p>
+        <p className="text-xs text-neutral-300 mt-2">Autosaves every ~0.45s when editing an existing note.</p>
       </section>
     </div>
   );

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -3,12 +3,36 @@ export default {
   content: ["./src/**/*.{astro,html,js,jsx,ts,tsx}"],
   theme: {
     extend: {
-      colors: {
-        brand: { 600: "#06b6d4" }
+      fontFamily: {
+        display: ["Poppins", "ui-sans-serif", "system-ui"],
+        body: ["Inter", "ui-sans-serif", "system-ui"]
       },
-      boxShadow: { soft: "0 10px 30px rgba(0,0,0,0.12)" },
-      keyframes: { fadeInUp: { "0%": { opacity: 0, transform: "translateY(8px)" }, "100%": { opacity: 1, transform: "translateY(0)" } } },
-      animation: { fadeInUp: "fadeInUp 400ms ease-out both" }
+      colors: {
+        base: "#070B12",
+        glass: "rgba(17, 24, 39, 0.55)",
+        neon: {
+          cyan: "#22d3ee",
+          pink: "#fb7185",
+          purple: "#a78bfa"
+        }
+      },
+      boxShadow: {
+        soft: "0 10px 30px rgba(0,0,0,0.25)",
+        glow: "0 0 40px rgba(34, 211, 238, 0.35)"
+      },
+      backdropBlur: {
+        xs: "2px"
+      },
+      keyframes: {
+        floaty: { "0%": { transform: "translateY(0)" }, "50%": { transform: "translateY(-10px)" }, "100%": { transform: "translateY(0)" } },
+        fadeUp: { "0%": { opacity: 0, transform: "translateY(12px)" }, "100%": { opacity: 1, transform: "translateY(0)" } },
+        pulseGlow: { "0%": { boxShadow: "0 0 0 rgba(34,211,238,0)" }, "50%": { boxShadow: "0 0 40px rgba(34,211,238,.35)" }, "100%": { boxShadow: "0 0 0 rgba(34,211,238,0)" } }
+      },
+      animation: {
+        floaty: "floaty 8s ease-in-out infinite",
+        fadeUp: "fadeUp .5s ease-out both",
+        pulseGlow: "pulseGlow 4s ease-in-out infinite"
+      }
     }
   },
   plugins: []


### PR DESCRIPTION
## Summary
- disable Jekyll for Pages
- rebuild as Astro + Tailwind + VitePWA with Dexie diary and tools
- add GitHub Actions workflow to build and deploy static site

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba2b8e8fd483238a21f2ea75892a65