### PR TITLE
Upgrade: neon-glass PWA with diary encryption, command palette and Pages base path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Build & Deploy (GitHub Pages)
+name: Build & Deploy (GitHub Pages, sexy-pro)
 
 on:
   push:
@@ -17,6 +17,9 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      BASE_PATH: "/${{ github.event.repository.name }}"
+      SITE_URL: "https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.nojekyll
+++ b/.nojekyll
@@ -1,1 +1,1 @@
-# Prevent GitHub from invoking Jekyll
+# Disable Jekyll entirely

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Portal (GitHub Pages PWA)
-Sexy, installable PWA with neon gradients, glassmorphism, and buttery motion. Local-only Diary (IndexedDB).
+# Portal Pro (GitHub Pages PWA)
+Neon-glass, keyboard-first, offline PWA. Markdown Diary with tags, fuzzy search, attachments, export/ZIP, and optional client-side encryption.
 
 ## Dev
 npm install
@@ -9,4 +9,9 @@ npm run dev
 npm run build
 
 ## Deploy
-Push to `main`. Ensure **Settings → Pages → Source = GitHub Actions**.
+Push to `main`. In **Settings → Pages** set **Source = GitHub Actions** (once).
+
+Tips
+- Press Ctrl/Cmd-K for the Command Palette.
+- Settings → theme, font size, language (EN/HE).
+- Diary → toggle encryption with a passphrase; data stays local.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,7 +3,11 @@ import tailwind from "@astrojs/tailwind";
 import react from "@astrojs/react";
 import astroPWA from "@vite-pwa/astro";
 
+const base = process.env.BASE_PATH || "/";
+
 export default defineConfig({
+  site: process.env.SITE_URL || "https://example.com",
+  base,
   trailingSlash: "ignore",
   integrations: [
     tailwind(),
@@ -14,9 +18,9 @@ export default defineConfig({
       manifest: {
         name: "Portal",
         short_name: "Portal",
-        description: "A sexy, offline-capable portal with a local diary & tools.",
-        start_url: ".",
-        scope: ".",
+        description: "Neon-glass PWA with local diary, tools, and zero-backend encryption.",
+        start_url: base,
+        scope: base,
         display: "standalone",
         background_color: "#070B12",
         theme_color: "#22d3ee",
@@ -26,7 +30,11 @@ export default defineConfig({
         ]
       },
       workbox: {
-        globPatterns: ["**/*.{js,css,html,svg,png,webp,woff2}"]
+        globPatterns: ["**/*.{js,css,html,svg,png,webp,woff2}"],
+        runtimeCaching: [
+          { urlPattern: ({request}) => request.destination === "image", handler: "CacheFirst", options: { cacheName: "img", expiration: { maxEntries: 60, maxAgeSeconds: 60*60*24*30 } } },
+          { urlPattern: ({url}) => url.origin === self.location.origin, handler: "StaleWhileRevalidate", options: { cacheName: "pages" } }
+        ]
       },
       devOptions: { enabled: true }
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,21 @@
 {
-  "name": "yaron-portal-pwa",
-  "version": "1.0.0",
+  "name": "portal-pwa-sexy-pro",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "yaron-portal-pwa",
-      "version": "1.0.0",
+      "name": "portal-pwa-sexy-pro",
+      "version": "2.0.0",
       "dependencies": {
         "@astrojs/react": "^4.3.0",
         "@astrojs/tailwind": "^5.1.0",
         "@vite-pwa/astro": "^0.4.1",
         "astro": "^4.14.0",
         "dexie": "^4.0.8",
+        "fuse.js": "^7.0.0",
+        "idb-keyval": "^6.2.1",
+        "marked": "^12.0.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -20,6 +23,7 @@
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "autoprefixer": "^10.4.20",
+        "jszip": "^3.10.1",
         "postcss": "^8.4.41",
         "prettier": "^3.3.3",
         "sharp": "^0.33.4",
@@ -4231,6 +4235,13 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5061,6 +5072,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/fuse.js": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
+      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -5543,6 +5563,19 @@
       "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
       "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
       "license": "ISC"
+    },
+    "node_modules/idb-keyval": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
+      "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/import-meta-resolve": {
       "version": "4.2.0",
@@ -6236,6 +6269,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dev": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -6261,6 +6307,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lilconfig": {
@@ -6444,6 +6500,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/math-intrinsics": {
@@ -7622,6 +7690,13 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parse-latin": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
@@ -7958,6 +8033,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -8070,6 +8152,36 @@
       "dependencies": {
         "pify": "^2.3.0"
       }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -8709,6 +8821,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/sharp": {
       "version": "0.33.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
@@ -8980,6 +9099,23 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "yaron-portal-pwa",
-  "version": "1.0.0",
+  "name": "portal-pwa-sexy-pro",
+  "version": "2.0.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -15,6 +15,9 @@
     "@astrojs/tailwind": "^5.1.0",
     "@vite-pwa/astro": "^0.4.1",
     "dexie": "^4.0.8",
+    "idb-keyval": "^6.2.1",
+    "marked": "^12.0.2",
+    "fuse.js": "^7.0.0",
     "@astrojs/react": "^4.3.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
@@ -26,6 +29,7 @@
     "sharp": "^0.33.4",
     "tailwindcss": "^3.4.10",
     "typescript": "^5.5.4",
+    "jszip": "^3.10.1",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0"
   }

--- a/public/icons/icon-maskable.svg
+++ b/public/icons/icon-maskable.svg
@@ -1,14 +1,6 @@
-<!-- One SVG source -> CI generates PNGs; no binaries tracked -->
+<!-- SVG only; PNGs generated in CI -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-  <defs>
-    <linearGradient id="g" x1="0" x2="1" y1="0" y2="1">
-      <stop offset="0%" stop-color="#22d3ee"/>
-      <stop offset="100%" stop-color="#a78bfa"/>
-    </linearGradient>
-  </defs>
+  <defs><linearGradient id="g" x1="0" x2="1" y1="0" y2="1"><stop offset="0%" stop-color="#22d3ee"/><stop offset="100%" stop-color="#a78bfa"/></linearGradient></defs>
   <rect width="512" height="512" rx="96" fill="url(#g)"/>
-  <g fill="white">
-    <circle cx="256" cy="196" r="68"/>
-    <path d="M128 352c0-50 53-92 128-92s128 42 128 92v32H128z"/>
-  </g>
+  <g fill="white"><circle cx="256" cy="196" r="68"/><path d="M128 352c0-50 53-92 128-92s128 42 128 92v32H128z"/></g>
 </svg>

--- a/scripts/gen-icons.mjs
+++ b/scripts/gen-icons.mjs
@@ -1,18 +1,8 @@
-import fs from "node:fs/promises";
-import path from "node:path";
-import sharp from "sharp";
+import fs from "node:fs/promises"; import path from "node:path"; import sharp from "sharp";
 const svgPath = path.resolve("public/icons/icon-maskable.svg");
-const outDir = path.resolve("public/icons");
-const sizes = [192, 512];
-const ensure = async p => fs.mkdir(p, { recursive: true }).catch(()=>{});
-const run = async () => {
-  await ensure(outDir);
-  const svg = await fs.readFile(svgPath);
-  await Promise.all(sizes.map(async s => {
-    const pngPath = path.join(outDir, `icon-${s}.png`);
-    const buf = await sharp(svg).resize(s, s, { fit: "cover" }).png().toBuffer();
-    await fs.writeFile(pngPath, buf);
-    console.log("Generated", pngPath);
-  }));
-};
-run().catch(e => { console.error(e); process.exit(1); });
+const outDir = path.resolve("public/icons"); const sizes = [192,512];
+const ensure = async p => fs.mkdir(p,{recursive:true}).catch(()=>{});
+const run = async () => { await ensure(outDir); const svg = await fs.readFile(svgPath);
+  await Promise.all(sizes.map(async s => { const png = path.join(outDir,`icon-${s}.png`);
+    const buf = await sharp(svg).resize(s,s,{fit:"cover"}).png().toBuffer(); await fs.writeFile(png,buf); console.log("Generated",png); }));
+}; run().catch(e=>{console.error(e);process.exit(1);});

--- a/src/components/CommandPalette.jsx
+++ b/src/components/CommandPalette.jsx
@@ -1,0 +1,30 @@
+import { useEffect, useRef, useState } from "react";
+const actions = [
+  { k:"g h", label:"Go Home", href:"./" },
+  { k:"g d", label:"Open Diary", href:"./diary" },
+  { k:"g t", label:"Open Tools", href:"./tools" },
+  { k:"g s", label:"Open Settings", href:"./settings" },
+  { k:"g a", label:"Open About", href:"./about" }
+];
+export default function CommandPalette(){
+  const [open,setOpen]=useState(false); const [q,setQ]=useState("");
+  const box = useRef(null);
+  useEffect(()=>{ const onKey=(e)=>{ if((e.ctrlKey||e.metaKey)&&e.key.toLowerCase()==="k"){ e.preventDefault(); setOpen(v=>!v);} }; window.addEventListener("keydown",onKey); return()=>window.removeEventListener("keydown",onKey);},[]);
+  useEffect(()=>{ if(open) box.current?.focus(); },[open]);
+  const list = actions.filter(a=>a.label.toLowerCase().includes(q.toLowerCase()));
+  return (<>
+    <button className="sr-only" onClick={()=>setOpen(true)}>Open command palette</button>
+    {open && <div role="dialog" aria-modal="true" className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm flex items-start justify-center p-4">
+      <div className="card w-full max-w-lg p-3">
+        <input ref={box} className="input mb-2" placeholder="Type a command…" value={q} onChange={e=>setQ(e.target.value)} />
+        <ul className="max-h-[50vh] overflow-auto">
+          {list.map(a=>(
+            <li key={a.k}><a className="block px-3 py-2 hover:bg-white/10 rounded-xl" href={a.href} onClick={()=>setOpen(false)}>{a.label} <span className="kbd ml-2">{a.k}</span></a></li>
+          ))}
+          {!list.length && <li className="px-3 py-2 text-sm text-neutral-300">No results</li>}
+        </ul>
+        <div className="text-right mt-2"><button className="btn-ghost" onClick={()=>setOpen(false)}>Close</button></div>
+      </div>
+    </div>}
+  </>);
+}

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -3,13 +3,14 @@ const tabs = [
   { href: "./", label: "Home", icon: "🏠" },
   { href: "./diary", label: "Diary", icon: "📝" },
   { href: "./tools", label: "Tools", icon: "🧰" },
+  { href: "./settings", label: "Settings", icon: "⚙️" },
   { href: "./about", label: "About", icon: "✨" }
 ];
 ---
 <nav class="fixed bottom-4 left-1/2 -translate-x-1/2 z-50">
   <div class="flex gap-2 bg-white/10 backdrop-blur-lg border border-white/15 rounded-3xl p-2 shadow-soft">
     {tabs.map(t => (
-      <a href={t.href} class="px-4 py-2 rounded-2xl bg-white/5 hover:bg-white/10 text-sm">{t.icon} {t.label}</a>
+      <a href={t.href} class="px-4 py-2 rounded-2xl bg-white/5 hover:bg-white/10 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-neon-cyan">{t.icon} {t.label}</a>
     ))}
   </div>
 </nav>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,2 +1,1 @@
-/// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,30 +1,29 @@
 ---
-const { title = "Portal", description = "A sexy, offline-capable portal with a local diary & tools." } = Astro.props;
+const { title = "Portal", description = "Neon-glass PWA with local diary & tools." } = Astro.props;
 import Nav from "../components/Nav.astro";
-const base = import.meta.env.BASE_URL;
+import CommandPalette from "../components/CommandPalette.jsx";
 ---
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#22d3ee" />
-    <title>{title}</title>
-    <meta name="description" content={description} />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <title>{title}</title><meta name="description" content={description} />
+    <link rel="preconnect" href="https://fonts.googleapis.com" /><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Poppins:wght@600;800&display=swap" rel="stylesheet" />
-    <link rel="manifest" href={base + "manifest.webmanifest"} />
-    <link rel="icon" href={base + "icons/icon-maskable.svg"} type="image/svg+xml" />
-    <link rel="apple-touch-icon" href={base + "icons/icon-maskable.svg"} />
-    <link rel="stylesheet" href={base + "src/styles/global.css"} />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="icon" href="/icons/icon-maskable.svg" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="/icons/icon-maskable.svg" />
+    <link rel="stylesheet" href="/src/styles/global.css" />
   </head>
   <body class="font-body">
+    <a class="skip" href="#main">Skip to content</a>
+
     <!-- Floating neon blobs -->
     <div class="pointer-events-none fixed inset-0 -z-10">
-      <div class="blob absolute top-[-10%] left-[5%] w-[45vw] h-[45vw] rounded-full bg-neon-cyan animate-floaty"></div>
-      <div class="blob absolute top-[0%] right-[5%] w-[35vw] h-[35vw] rounded-full bg-neon-purple animate-floaty" style="animation-delay: -2s"></div>
-      <div class="blob absolute bottom-[-10%] left-[30%] w-[40vw] h-[40vw] rounded-full bg-neon-pink animate-floaty" style="animation-delay: -4s"></div>
+      <div class="absolute top-[-10%] left-[5%] w-[45vw] h-[45vw] rounded-full bg-neon-cyan blur-3xl opacity-40 animate-floaty"></div>
+      <div class="absolute top-[0%] right-[5%] w-[35vw] h-[35vw] rounded-full bg-neon-purple blur-3xl opacity-40 animate-floaty" style="animation-delay:-2s"></div>
+      <div class="absolute bottom-[-10%] left-[30%] w-[40vw] h-[40vw] rounded-full bg-neon-pink blur-3xl opacity-30 animate-floaty" style="animation-delay:-4s"></div>
     </div>
 
     <header class="container py-6">
@@ -33,28 +32,29 @@ const base = import.meta.env.BASE_URL;
         <div class="flex items-center gap-2">
           <a href="./diary" class="btn-ghost text-sm">Diary</a>
           <a href="./tools" class="btn-ghost text-sm">Tools</a>
+          <a href="./settings" class="btn-ghost text-sm">Settings</a>
           <a href="./about" class="btn-ghost text-sm">About</a>
         </div>
       </nav>
     </header>
 
-    <main class="container pb-28">
+    <main id="main" class="container pb-28">
       <slot />
     </main>
 
     <Nav />
+    <CommandPalette client:load />
 
-    <footer class="container py-10 text-center text-muted">
-      <p>Installable PWA • Offline • Text-only repo (icons generated in CI)</p>
+    <footer class="container py-10 text-center text-neutral-300">
+      <p>Installable PWA • Offline • Text-only repo (icons generated in CI) • Press <span class="kbd">Ctrl/Cmd-K</span></p>
     </footer>
 
     <script type="module">
-      // PWA update toast
       if ("serviceWorker" in navigator) {
         navigator.serviceWorker.addEventListener("controllerchange", () => {
           const bar = document.createElement("div");
           bar.textContent = "Updated. Tap to reload.";
-          Object.assign(bar.style, { position: "fixed", inset: "auto 1rem 1rem 1rem", background:"#22d3ee", color:"#06131a",
+          Object.assign(bar.style, { position:"fixed", inset:"auto 1rem 1rem 1rem", background:"#22d3ee", color:"#06131a",
             padding:"0.8rem 1rem", borderRadius:"1rem", fontWeight:"700", textAlign:"center", zIndex:"9999", boxShadow:"0 10px 30px rgba(0,0,0,.3)", cursor:"pointer" });
           bar.onclick = () => location.reload();
           document.body.appendChild(bar);

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -1,0 +1,21 @@
+/** Client-side AES-GCM helpers (Web Crypto) for optional encryption */
+export async function deriveKey(pass:string, salt:Uint8Array){
+  const enc = new TextEncoder();
+  const keyMaterial = await crypto.subtle.importKey("raw", enc.encode(pass), "PBKDF2", false, ["deriveKey"]);
+  return crypto.subtle.deriveKey({name:"PBKDF2", salt, iterations:150000, hash:"SHA-256"},
+    keyMaterial, {name:"AES-GCM", length:256}, false, ["encrypt","decrypt"]);
+}
+export async function encryptJSON(pass:string, data:any){
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const key = await deriveKey(pass, salt);
+  const pt = new TextEncoder().encode(JSON.stringify(data));
+  const ct = new Uint8Array(await crypto.subtle.encrypt({name:"AES-GCM", iv}, key, pt));
+  return { salt: Array.from(salt), iv: Array.from(iv), ct: Array.from(ct) };
+}
+export async function decryptJSON(pass:string, payload:any){
+  const {salt, iv, ct} = payload;
+  const key = await deriveKey(pass, new Uint8Array(salt));
+  const pt = await crypto.subtle.decrypt({name:"AES-GCM", iv:new Uint8Array(iv)}, key, new Uint8Array(ct));
+  return JSON.parse(new TextDecoder().decode(new Uint8Array(pt)));
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,5 +1,13 @@
 import Dexie, { type Table } from "dexie";
-export interface Entry { id?: number; createdAt: number; updatedAt: number; title: string; body: string; tags: string[]; }
-class DiaryDB extends Dexie { entries!: Table<Entry, number>;
-  constructor(){ super("portal-diary"); this.version(1).stores({ entries: "++id, createdAt, updatedAt, title" }); } }
+export interface Attachment { id?:number; entryId:number; name:string; type:string; size:number; createdAt:number; data:Blob; }
+export interface Entry { id?:number; createdAt:number; updatedAt:number; title:string; body:string; tags:string[]; pinned:boolean; archived:boolean; trashed:boolean; enc?:boolean; }
+class DiaryDB extends Dexie {
+  entries!: Table<Entry, number>; attachments!: Table<Attachment, number>;
+  constructor(){ super("portal-diary-pro");
+    this.version(3).stores({
+      entries: "++id, createdAt, updatedAt, title, pinned, archived, trashed",
+      attachments: "++id, entryId, createdAt"
+    });
+  }
+}
 export const db = new DiaryDB();

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,0 +1,9 @@
+export type Lang = "en" | "he";
+export const t = (lang:Lang, key:string) => {
+  const dict:any = {
+    en: { welcome:"Welcome", install:"Install App", diary:"Diary", tools:"Tools", settings:"Settings", about:"About",
+      offline:"Works offline", installable:"Installable", textOnly:"Text-only repo" },
+    he: { welcome:"ברוך הבא", install:"התקן אפליקציה", diary:"יומן", tools:"כלים", settings:"הגדרות", about:"עלינו",
+      offline:"פועל ללא אינטרנט", installable:"ניתן להתקנה", textOnly:"מאגר ללא קבצים בינאריים" }
+  }; return (dict[lang]&&dict[lang][key]) || key;
+};

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -5,12 +5,7 @@ import Base from "../layouts/Base.astro";
   <section class="grid gap-6">
     <div class="card p-6 animate-fadeUp">
       <h1 class="text-2xl font-display font-extrabold mb-2">About</h1>
-      <p class="text-muted">This PWA is hosted on GitHub Pages, works offline, and keeps the repo text-only by generating icons in CI.</p>
-      <ul class="list-disc pl-6 mt-3 text-muted space-y-1">
-        <li>Astro + Tailwind + VitePWA</li>
-        <li>Neon gradient aesthetic, glass cards, micro-interactions</li>
-        <li>Local Diary (IndexedDB). No external backend.</li>
-      </ul>
+      <p class="text-neutral-300">Installable PWA hosted on GitHub Pages. Text-only repo (icons generated in CI). Keyboard UX, a11y, and privacy-first by design.</p>
     </div>
   </section>
 </Base>

--- a/src/pages/diary.astro
+++ b/src/pages/diary.astro
@@ -2,11 +2,11 @@
 import Base from "../layouts/Base.astro";
 import DiaryApp from "../ui/DiaryApp.jsx";
 ---
-<Base title="Portal • Diary" description="Offline local diary with search, tags, backups.">
+<Base title="Portal • Diary" description="Markdown diary with tags, fuzzy search, encryption, and attachments.">
   <section class="grid gap-6">
     <div class="card p-5 animate-fadeUp">
       <h1 class="text-2xl font-display font-extrabold mb-1">Diary</h1>
-      <p class="text-muted">Saved locally on this device. Export/Import JSON to move between devices.</p>
+      <p class="text-neutral-300">Private, offline-first. Optional client-side encryption.</p>
     </div>
     <DiaryApp client:load />
   </section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,43 +5,24 @@ import Base from "../layouts/Base.astro";
   <section class="grid gap-6">
     <div class="card p-7 animate-fadeUp">
       <h1 class="text-4xl font-display font-extrabold mb-2 leading-tight">Your personal <span class="text-neon-cyan">Portal</span></h1>
-      <p class="text-muted">Gorgeous, fast, installable. Built for offline use with buttery motion and a privacy-friendly local diary.</p>
+      <p class="text-neutral-300">Glassy UI, buttery motion, keyboard-driven navigation, offline diary with optional encryption.</p>
       <div class="mt-6 flex flex-wrap gap-3">
-        <a href="./diary" class="btn-primary animate-pulseGlow">Open Diary</a>
+        <a href="./diary" class="btn-primary">Open Diary</a>
         <a href="./tools" class="btn-ghost">Open Tools</a>
+        <a href="./settings" class="btn-ghost">Settings</a>
         <button id="installBtn" class="btn-ghost" style="display:none">Install App</button>
       </div>
     </div>
-
     <div class="grid md:grid-cols-3 gap-4">
-      <div class="card p-5 animate-fadeUp" style="animation-delay:80ms">
-        <h3 class="font-semibold mb-1">Offline-first</h3>
-        <p class="text-sm text-muted">Works without internet. Your data stays on this device unless you export it.</p>
-      </div>
-      <div class="card p-5 animate-fadeUp" style="animation-delay:140ms">
-        <h3 class="font-semibold mb-1">Installable</h3>
-        <p class="text-sm text-muted">Add to Home Screen on Android for a native-like experience.</p>
-      </div>
-      <div class="card p-5 animate-fadeUp" style="animation-delay:200ms">
-        <h3 class="font-semibold mb-1">Text-only repo</h3>
-        <p class="text-sm text-muted">No binaries tracked. Icons are generated in CI from a single SVG.</p>
-      </div>
+      <div class="card p-5 animate-fadeUp" style="animation-delay:80ms"><h3 class="font-semibold mb-1">Offline-first</h3><p class="text-sm text-neutral-300">Works without internet.</p></div>
+      <div class="card p-5 animate-fadeUp" style="animation-delay:140ms"><h3 class="font-semibold mb-1">Keyboard UX</h3><p class="text-sm text-neutral-300"><span class="kbd">Ctrl/Cmd-K</span> opens the Command Palette.</p></div>
+      <div class="card p-5 animate-fadeUp" style="animation-delay:200ms"><h3 class="font-semibold mb-1">Private</h3><p class="text-sm text-neutral-300">Optional client-side encryption.</p></div>
     </div>
   </section>
 
   <script>
-    let deferredPrompt;
-    const btn = document.getElementById("installBtn");
-    window.addEventListener("beforeinstallprompt", (e) => {
-      e.preventDefault();
-      deferredPrompt = e;
-      btn.style.display = "inline-flex";
-    });
-    btn?.addEventListener("click", async () => {
-      if (!deferredPrompt) return;
-      deferredPrompt.prompt();
-      await deferredPrompt.userChoice;
-      deferredPrompt = null;
-    });
+    let deferredPrompt; const btn = document.getElementById("installBtn");
+    window.addEventListener("beforeinstallprompt",(e)=>{ e.preventDefault(); deferredPrompt=e; btn.style.display="inline-flex"; });
+    btn?.addEventListener("click", async ()=>{ if(!deferredPrompt) return; deferredPrompt.prompt(); await deferredPrompt.userChoice; deferredPrompt=null; });
   </script>
 </Base>

--- a/src/pages/settings.astro
+++ b/src/pages/settings.astro
@@ -1,0 +1,47 @@
+---
+import Base from "../layouts/Base.astro";
+---
+<Base title="Portal • Settings">
+  <section class="grid gap-6">
+    <div class="card p-6 animate-fadeUp">
+      <h2 class="text-xl font-semibold mb-3">Appearance</h2>
+      <div class="flex flex-wrap gap-2">
+        <button class="btn-ghost" id="themeSys">System</button>
+        <button class="btn-ghost" id="themeLight">Light</button>
+        <button class="btn-ghost" id="themeDark">Dark</button>
+        <div class="flex items-center gap-2 ml-2">
+          <span class="text-sm text-neutral-300">Font size</span>
+          <input type="range" id="fontScale" min="90" max="125" value="100" />
+        </div>
+      </div>
+    </div>
+
+    <div class="card p-6 animate-fadeUp">
+      <h2 class="text-xl font-semibold mb-3">Language</h2>
+      <div class="flex gap-2">
+        <button class="btn-ghost" id="langEn">English</button>
+        <button class="btn-ghost" id="langHe">עברית</button>
+      </div>
+    </div>
+  </section>
+
+  <script type="module">
+    const root = document.documentElement;
+    const ls = localStorage;
+    const apply = ()=>{
+      const theme = ls.getItem("theme")||"system";
+      root.dataset.theme = theme;
+      const scale = parseInt(ls.getItem("fontScale")||"100",10);
+      root.style.fontSize = scale+"%";
+      document.dir = (ls.getItem("lang")||"en")==="he" ? "rtl" : "ltr";
+      document.documentElement.lang = ls.getItem("lang")||"en";
+    };
+    apply();
+    document.getElementById("themeSys").onclick = ()=>{ ls.setItem("theme","system"); apply(); };
+    document.getElementById("themeLight").onclick = ()=>{ ls.setItem("theme","light"); apply(); };
+    document.getElementById("themeDark").onclick = ()=>{ ls.setItem("theme","dark"); apply(); };
+    document.getElementById("fontScale").oninput = (e)=>{ ls.setItem("fontScale", e.target.value); apply(); };
+    document.getElementById("langEn").onclick = ()=>{ ls.setItem("lang","en"); apply(); };
+    document.getElementById("langHe").onclick = ()=>{ ls.setItem("lang","he"); apply(); };
+  </script>
+</Base>

--- a/src/pages/tools.astro
+++ b/src/pages/tools.astro
@@ -9,21 +9,21 @@ import Base from "../layouts/Base.astro";
         <div class="card p-4">
           <h3 class="font-semibold mb-2">Word Counter</h3>
           <textarea id="wc" class="input min-h-[24vh]" placeholder="Paste text…"></textarea>
-          <div class="mt-2 text-sm text-muted">Words: <span id="wcout">0</span> • Chars: <span id="ccout">0</span></div>
+          <div class="mt-2 text-sm text-neutral-300">Words: <span id="wcout">0</span> • Chars: <span id="ccout">0</span></div>
         </div>
         <div class="card p-4">
           <h3 class="font-semibold mb-2">Unit: cm → inches</h3>
           <input id="cm" class="input" placeholder="Enter cm…" />
-          <div class="mt-2 text-sm text-muted">Inches: <span id="inch">0</span></div>
+          <div class="mt-2 text-sm text-neutral-300">Inches: <span id="inch">0</span></div>
         </div>
       </div>
     </div>
   </section>
 
   <script>
-    const wc = document.getElementById('wc'), wcout = document.getElementById('wcout'), ccout = document.getElementById('ccout');
-    wc?.addEventListener('input', ()=>{ const t = wc.value || ""; wcout.textContent = (t.trim().match(/\S+/g)||[]).length; ccout.textContent = t.length; });
-    const cm = document.getElementById('cm'), inch = document.getElementById('inch');
-    cm?.addEventListener('input', ()=>{ const v = parseFloat(cm.value||"0"); inch.textContent = isNaN(v) ? "0" : (v/2.54).toFixed(2); });
+    const wc=document.getElementById('wc'), wcout=document.getElementById('wcout'), ccout=document.getElementById('ccout');
+    wc?.addEventListener('input',()=>{ const t=wc.value||""; wcout.textContent=(t.trim().match(/\S+/g)||[]).length; ccout.textContent=t.length; });
+    const cm=document.getElementById('cm'), inch=document.getElementById('inch');
+    cm?.addEventListener('input',()=>{ const v=parseFloat(cm.value||"0"); inch.textContent = isNaN(v)?"0":(v/2.54).toFixed(2); });
   </script>
 </Base>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,24 +1,13 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
-:root { color-scheme: light dark; }
-
-html, body { height: 100%; }
-body { @apply bg-[radial-gradient(1200px_600px_at_10%_-10%,#0ea5e9,transparent),radial-gradient(1000px_500px_at_90%_10%,#a78bfa,transparent),bg-base text-neutral-100 antialiased; }
-
-.container { @apply max-w-screen-md mx-auto px-4; }
-
-.card { @apply bg-glass backdrop-blur-md rounded-3xl border border-white/10 shadow-soft; }
-
-.btn { @apply inline-flex items-center justify-center gap-2 rounded-2xl px-4 py-2 font-semibold transition active:scale-95; }
-.btn-primary { @apply btn bg-neon-cyan text-black hover:brightness-110 shadow-glow; }
-.btn-ghost { @apply btn bg-white/5 hover:bg-white/10 border border-white/10; }
-
-.input { @apply w-full rounded-2xl bg-white/5 border border-white/10 px-4 py-3 outline-none focus:ring-2 focus:ring-neon-cyan; }
-.text-muted { @apply text-neutral-300; }
-
-.blob {
-  filter: blur(40px);
-  opacity: .4;
-}
+@tailwind base; @tailwind components; @tailwind utilities;
+:root{ color-scheme: light dark; }
+@media (prefers-reduced-motion: reduce){ *{ animation: none !important; transition: none !important; } }
+html,body{ height:100%; } 
+body{ @apply bg-[radial-gradient(1200px_600px_at_10%_-10%,#0ea5e9,transparent),radial-gradient(1000px_500px_at_90%_10%,#a78bfa,transparent),bg-base text-neutral-100 antialiased; }
+.container{ @apply max-w-screen-md mx-auto px-4; }
+.card{ @apply bg-glass backdrop-blur-md rounded-3xl border border-white/10 shadow-soft; }
+.btn{ @apply inline-flex items-center justify-center gap-2 rounded-2xl px-4 py-2 font-semibold transition active:scale-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-neon-cyan; }
+.btn-primary{ @apply btn bg-neon-cyan text-black hover:brightness-110 shadow-glow; }
+.btn-ghost{ @apply btn bg-white/5 hover:bg-white/10 border border-white/10; }
+.input{ @apply w-full rounded-2xl bg-white/5 border border-white/10 px-4 py-3 outline-none focus:ring-2 focus:ring-neon-cyan; }
+.kbd{ @apply inline-block rounded border border-white/20 px-1.5 py-0.5 text-xs; }
+.skip{ position:absolute; left:-9999px; top:auto; width:1px; height:1px; overflow:hidden; } .skip:focus{ left:1rem; top:1rem; width:auto; height:auto; @apply bg-neon-cyan text-black px-3 py-2 rounded-xl; }

--- a/src/ui/DiaryApp.jsx
+++ b/src/ui/DiaryApp.jsx
@@ -1,55 +1,157 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { db } from "../lib/db";
+import Fuse from "fuse.js";
+import { marked } from "marked";
+import { encryptJSON, decryptJSON } from "../lib/crypto";
+
 const fmt = (ms)=> new Date(ms).toLocaleString();
 const toTags = (s)=> s.split(",").map(t=>t.trim()).filter(Boolean);
 
 export default function DiaryApp(){
-  const [entries,setEntries]=useState([]), [q,setQ]=useState(""), [tagQ,setTagQ]=useState(""),
-        [title,setTitle]=useState(""), [body,setBody]=useState(""), [tags,setTags]=useState(""),
-        [selectedId,setSelectedId]=useState(null); const fileRef=useRef(null);
+  const [entries,setEntries]=useState([]), [q,setQ]=useState(""),
+        [title,setTitle]=useState(""), [body,setBody]=useState(""),
+        [tags,setTags]=useState(""), [selected,setSelected]=useState(null),
+        [filter,setFilter]=useState("all"), [pass,setPass]=useState(""), [encOn,setEncOn]=useState(false);
+  const fileRef=useRef(null), dropRef=useRef(null);
 
   const refresh=async()=> setEntries(await db.entries.orderBy("createdAt").reverse().toArray());
-  useEffect(()=>{refresh();},[]);
-  useEffect(()=>{const h=setTimeout(async()=>{ if(!title && !body) return; if(selectedId){ await db.entries.update(selectedId,{title,body,tags:toTags(tags),updatedAt:Date.now()}); refresh();}},450); return()=>clearTimeout(h);},[title,body,tags,selectedId]);
+  useEffect(()=>{ refresh(); },[]);
+  useEffect(()=>{ const h=setTimeout(async()=>{ if(selected){ await db.entries.update(selected.id,{title,body,tags:toTags(tags),updatedAt:Date.now()}); refresh(); } },450); return()=>clearTimeout(h);},[title,body,tags,selected]);
 
-  async function createNew(){ const id=await db.entries.add({createdAt:Date.now(),updatedAt:Date.now(),title:title||"Untitled",body:body||"",tags:toTags(tags)}); setSelectedId(id); refresh(); }
-  function selectEntry(e){ setSelectedId(e.id); setTitle(e.title); setBody(e.body); setTags((e.tags||[]).join(", ")); }
-  async function save(){ if(!selectedId) return createNew(); await db.entries.update(selectedId,{title,body,tags:toTags(tags),updatedAt:Date.now()}); refresh(); }
-  async function del(id){ await db.entries.delete(id); if(selectedId===id){ setSelectedId(null); setTitle(""); setBody(""); setTags(""); } refresh(); }
-  const filtered=()=>entries.filter(e=>{ const QQ=q.toLowerCase(), TT=tagQ.toLowerCase(); const mq=!QQ || e.title.toLowerCase().includes(QQ) || e.body.toLowerCase().includes(QQ); const mt=!TT || (e.tags||[]).some(t=>t.toLowerCase().includes(TT)); return mq&&mt; });
-  async function exportJSON(){ const dump=await db.entries.toArray(); const blob=new Blob([JSON.stringify({version:1,exportedAt:Date.now(),entries:dump},null,2)],{type:"application/json"}); const url=URL.createObjectURL(blob); const a=document.createElement("a"); a.href=url; a.download="diary-backup.json"; a.click(); URL.revokeObjectURL(url); }
-  async function importJSON(file){ const data=JSON.parse(await file.text()); if(!data.entries) return alert("Invalid file."); await db.transaction("rw",db.entries,async()=>{ for(const e of data.entries){ if(e.id){ const ex=await db.entries.get(e.id); ex? await db.entries.update(e.id,e): await db.entries.add(e);} else { await db.entries.add(e);} } }); refresh(); }
+  const fuse = useMemo(()=> new Fuse(entries, { keys:["title","body","tags"], threshold:0.33 }), [entries]);
+  const list = useMemo(()=>{
+    let base = filter==="all"? entries : entries.filter(e=> filter==="pinned" ? e.pinned : filter==="archived" ? e.archived : filter==="trash" ? e.trashed : true);
+    if(q.trim()) base = fuse.search(q).map(r=>r.item);
+    return base;
+  }, [entries,q,filter,fuse]);
+
+  async function createNew(){ const id=await db.entries.add({createdAt:Date.now(),updatedAt:Date.now(),title:title||"Untitled",body:body||"",tags:toTags(tags),pinned:false,archived:false,trashed:false}); const e=await db.entries.get(id); setSelected(e); refresh(); }
+  async function select(e){ setSelected(e); setTitle(e.title); setBody(e.body); setTags((e.tags||[]).join(", ")); }
+  async function save(){ if(!selected) return createNew(); await db.entries.update(selected.id,{title,body,tags:toTags(tags),updatedAt:Date.now()}); refresh(); }
+  async function toggle(id,field){ const v = await db.entries.get(id); await db.entries.update(id,{[field]:!v[field]}); if(selected?.id===id) setSelected({...v,[field]:!v[field]}); refresh(); }
+  async function del(id){ await db.entries.update(id,{trashed:true}); if(selected?.id===id) setSelected(null); refresh(); }
+  async function hardDel(id){ await db.entries.delete(id); refresh(); }
+  async function restore(id){ await db.entries.update(id,{trashed:false}); refresh(); }
+
+  // Attachments
+  async function addFiles(files){
+    if(!selected){ await createNew(); }
+    const entryId = selected?.id || (await db.entries.orderBy("id").last()).id;
+    for(const f of files){ const data = await f.arrayBuffer(); await db.attachments.add({ entryId, name:f.name, type:f.type, size:f.size, createdAt:Date.now(), data:new Blob([data],{type:f.type}) }); }
+    refresh();
+  }
+  useEffect(()=>{ const el=dropRef.current; if(!el) return;
+    const stop=e=>{e.preventDefault(); e.stopPropagation();};
+    const onDrop=e=>{ stop(e); addFiles(e.dataTransfer.files); };
+    ["dragenter","dragover","dragleave","drop"].forEach(ev=> el.addEventListener(ev, stop));
+    el.addEventListener("drop", onDrop); return ()=>{ ["dragenter","dragover","dragleave","drop"].forEach(ev=> el.removeEventListener(ev, stop)); el.removeEventListener("drop", onDrop); };
+  },[selected]);
+
+  // Export / Import
+  async function exportJSON(){
+    const dump = await db.entries.toArray();
+    const atts = await db.attachments.toArray();
+    const blob = new Blob([JSON.stringify({v:2, exportedAt:Date.now(), entries:dump, attachmentsMeta: atts.map(a=>({id:a.id,entryId:a.entryId,name:a.name,type:a.type,size:a.size,createdAt:a.createdAt}))},null,2)],{type:"application/json"});
+    const url = URL.createObjectURL(blob); const a=document.createElement("a"); a.href=url; a.download="diary.json"; a.click(); URL.revokeObjectURL(url);
+  }
+  async function exportZIP(){
+    const { default: JSZip } = await import("jszip"); const zip = new JSZip();
+    const dump = await db.entries.toArray(); zip.file("entries.json", JSON.stringify(dump,null,2));
+    const atts = await db.attachments.toArray(); const folder = zip.folder("attachments");
+    for(const a of atts){ const buffer = await a.data.arrayBuffer(); folder.file(`${a.id}-${a.name}`, buffer); }
+    const blob = await zip.generateAsync({type:"blob"}); const url = URL.createObjectURL(blob); const link=document.createElement("a"); link.href=url; link.download="diary.zip"; link.click(); URL.revokeObjectURL(url);
+  }
+  async function importJSON(file){
+    const text = await file.text(); const data = JSON.parse(text);
+    if(!data.entries && !data.v) return alert("Invalid file.");
+    await db.transaction("rw", db.entries, db.attachments, async ()=>{
+      if(data.entries){ for(const e of data.entries){ e.id ? (await db.entries.put(e)) : (await db.entries.add(e)); } }
+    });
+    refresh();
+  }
+
+  // Encryption
+  async function encryptSelected(){
+    if(!selected) return; if(!pass) return alert("Set a passphrase first in the bar below.");
+    const payload = await encryptJSON(pass, { title, body, tags: toTags(tags) });
+    await db.entries.update(selected.id, { body: JSON.stringify(payload), title: "(Encrypted)", tags: [], enc: true, updatedAt: Date.now() });
+    setBody("(Encrypted)"); setTitle("(Encrypted)"); setTags(""); refresh();
+  }
+  async function decryptSelected(){
+    if(!selected || !selected.enc) return; if(!pass) return alert("Enter passphrase.");
+    try{
+      const payload = await decryptJSON(pass, JSON.parse(selected.body));
+      setTitle(payload.title); setBody(payload.body); setTags((payload.tags||[]).join(", "));
+      await db.entries.update(selected.id, { enc:false, title: payload.title, body: payload.body, tags: payload.tags||[] });
+      refresh();
+    }catch{ alert("Bad passphrase."); }
+  }
 
   return (
-    <div className="grid gap-4 md:grid-cols-[280px_1fr]">
+    <div className="grid gap-4 md:grid-cols-[300px_1fr]">
+      {/* Sidebar */}
       <aside className="card p-4 h-max sticky top-4">
-        <input className="input mb-2" placeholder="Search…" value={q} onChange={e=>setQ(e.target.value)} />
-        <input className="input mb-3" placeholder="Filter by tag…" value={tagQ} onChange={e=>setTagQ(e.target.value)} />
-        <button className="btn-primary w-full mb-4" onClick={createNew}>New Entry</button>
-        <div className="max-h-[50vh] overflow-auto pr-1 space-y-2">
-          {filtered().map(e=>(
-            <button key={e.id} onClick={()=>selectEntry(e)} className={`w-full text-left p-3 rounded-2xl border transition ${selectedId===e.id?"border-white/30 bg-white/10":"border-white/10 hover:bg-white/5"}`}>
-              <div className="font-semibold">{e.title||"Untitled"}</div>
-              <div className="text-muted text-xs">{fmt(e.updatedAt)}</div>
-              {e.tags?.length ? <div className="mt-1 text-xs text-neutral-300">#{e.tags.join(" #")}</div> : null}
-            </button>
+        <div className="flex gap-2 mb-3">
+          <input className="input" placeholder="Search…" value={q} onChange={e=>setQ(e.target.value)} />
+        </div>
+        <div className="flex gap-2 mb-3">
+          {["all","pinned","archived","trash"].map(f=>(
+            <button key={f} className={`btn-ghost text-sm ${filter===f?"ring-2 ring-neon-cyan":""}`} onClick={()=>setFilter(f)}>{f}</button>
           ))}
-          {!filtered().length && <div className="text-muted text-sm">No entries yet.</div>}
+        </div>
+        <button className="btn-primary w-full mb-3" onClick={createNew}>New Entry</button>
+        <div className="max-h-[50vh] overflow-auto pr-1 space-y-2">
+          {list.map(e=>(
+            <div key={e.id} className={`p-3 rounded-2xl border ${selected?.id===e.id?"border-white/30 bg-white/10":"border-white/10 hover:bg-white/5"}`}>
+              <button className="w-full text-left" onClick={()=>select(e)}>
+                <div className="font-semibold">{e.title||"Untitled"}</div>
+                <div className="text-neutral-400 text-xs">{fmt(e.updatedAt)}</div>
+                {!!e.tags?.length && <div className="mt-1 text-xs text-neutral-300">#{e.tags.join(" #")}</div>}
+              </button>
+              <div className="flex gap-2 mt-2">
+                <button className="btn-ghost text-xs" onClick={()=>toggle(e.id,"pinned")}>{e.pinned?"Unpin":"Pin"}</button>
+                <button className="btn-ghost text-xs" onClick={()=>toggle(e.id,"archived")}>{e.archived?"Unarchive":"Archive"}</button>
+                {!e.trashed ? <button className="btn-ghost text-xs" onClick={()=>del(e.id)}>Trash</button> : <>
+                  <button className="btn-ghost text-xs" onClick={()=>restore(e.id)}>Restore</button>
+                  <button className="btn-ghost text-xs" onClick={()=>hardDel(e.id)}>Delete</button>
+                </>}
+              </div>
+            </div>
+          ))}
+          {!list.length && <div className="text-neutral-400 text-sm">No entries.</div>}
         </div>
       </aside>
 
-      <section className="card p-4 animate-fadeUp">
-        <input className="input text-xl font-semibold mb-3" placeholder="Title…" value={title} onChange={e=>setTitle(e.target.value)} />
-        <textarea className="input min-h-[40vh] mb-3" placeholder="Write your thoughts…" value={body} onChange={e=>setBody(e.target.value)} />
-        <input className="input mb-3" placeholder="tags, comma,separated" value={tags} onChange={e=>setTags(e.target.value)} />
-        <div className="flex flex-wrap gap-2">
-          <button className="btn-primary" onClick={save}>Save</button>
-          {selectedId && <button className="btn-ghost" onClick={()=>del(selectedId)}>Delete</button>}
-          <button className="btn-ghost" onClick={exportJSON}>Export</button>
-          <input ref={fileRef} type="file" accept="application/json" className="hidden" onChange={e=>e.target.files[0]&&importJSON(e.target.files[0])} />
-          <button className="btn-ghost" onClick={()=>fileRef.current?.click()}>Import</button>
+      {/* Editor */}
+      <section className="card p-4 animate-fadeUp" ref={dropRef}>
+        <div className="grid gap-3">
+          <input className="input text-xl font-semibold" placeholder="Title…" value={title} onChange={e=>setTitle(e.target.value)} />
+          <div className="grid md:grid-cols-2 gap-3">
+            <textarea className="input min-h-[40vh]" placeholder="Write in **Markdown**…" value={body} onChange={e=>setBody(e.target.value)} />
+            <div className="input min-h-[40vh] overflow-auto prose prose-invert" dangerouslySetInnerHTML={{__html: marked.parse(body || "")}} />
+          </div>
+          <input className="input" placeholder="tags, comma,separated" value={tags} onChange={e=>setTags(e.target.value)} />
+          <div className="flex flex-wrap gap-2">
+            <button className="btn-primary" onClick={save}>Save</button>
+            {selected && <>
+              <button className="btn-ghost" onClick={()=>toggle(selected.id,"pinned")}>{selected.pinned?"Unpin":"Pin"}</button>
+              <button className="btn-ghost" onClick={()=>toggle(selected.id,"archived")}>{selected.archived?"Unarchive":"Archive"}</button>
+              <button className="btn-ghost" onClick={()=>del(selected.id)}>Trash</button>
+            </>}
+            <button className="btn-ghost" onClick={exportJSON}>Export JSON</button>
+            <button className="btn-ghost" onClick={exportZIP}>Export ZIP</button>
+            <input ref={fileRef} type="file" accept="application/json" className="hidden" onChange={e=>e.target.files[0]&&importJSON(e.target.files[0])} />
+            <button className="btn-ghost" onClick={()=>fileRef.current?.click()}>Import JSON</button>
+          </div>
+
+          <div className="mt-2 flex flex-wrap gap-2 items-center">
+            <input className="input w-auto" placeholder="passphrase (optional)" value={pass} onChange={e=>setPass(e.target.value)} />
+            <button className="btn-ghost" onClick={()=>setEncOn(!encOn)}>{encOn?"Encryption: ON":"Encryption: OFF"}</button>
+            {selected && !selected.enc && encOn && <button className="btn-ghost" onClick={encryptSelected}>Encrypt note</button>}
+            {selected?.enc && <button className="btn-ghost" onClick={decryptSelected}>Decrypt note</button>}
+            <span className="text-neutral-400 text-xs">Drag files here to attach</span>
+          </div>
         </div>
-        <p className="text-xs text-neutral-300 mt-2">Autosaves every ~0.45s when editing an existing note.</p>
       </section>
     </div>
   );

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -3,36 +3,18 @@ export default {
   content: ["./src/**/*.{astro,html,js,jsx,ts,tsx}"],
   theme: {
     extend: {
-      fontFamily: {
-        display: ["Poppins", "ui-sans-serif", "system-ui"],
-        body: ["Inter", "ui-sans-serif", "system-ui"]
-      },
+      fontFamily: { display: ["Poppins","ui-sans-serif","system-ui"], body: ["Inter","ui-sans-serif","system-ui"] },
       colors: {
         base: "#070B12",
-        glass: "rgba(17, 24, 39, 0.55)",
-        neon: {
-          cyan: "#22d3ee",
-          pink: "#fb7185",
-          purple: "#a78bfa"
-        }
+        glass: "rgba(17,24,39,0.55)",
+        neon: { cyan: "#22d3ee", pink: "#fb7185", purple: "#a78bfa" }
       },
-      boxShadow: {
-        soft: "0 10px 30px rgba(0,0,0,0.25)",
-        glow: "0 0 40px rgba(34, 211, 238, 0.35)"
-      },
-      backdropBlur: {
-        xs: "2px"
-      },
+      boxShadow: { soft: "0 10px 30px rgba(0,0,0,0.25)", glow: "0 0 40px rgba(34,211,238,0.35)" },
       keyframes: {
-        floaty: { "0%": { transform: "translateY(0)" }, "50%": { transform: "translateY(-10px)" }, "100%": { transform: "translateY(0)" } },
-        fadeUp: { "0%": { opacity: 0, transform: "translateY(12px)" }, "100%": { opacity: 1, transform: "translateY(0)" } },
-        pulseGlow: { "0%": { boxShadow: "0 0 0 rgba(34,211,238,0)" }, "50%": { boxShadow: "0 0 40px rgba(34,211,238,.35)" }, "100%": { boxShadow: "0 0 0 rgba(34,211,238,0)" } }
+        floaty: { "0%":{transform:"translateY(0)"}, "50%":{transform:"translateY(-10px)"}, "100%":{transform:"translateY(0)"} },
+        fadeUp: { "0%":{opacity:0,transform:"translateY(12px)"}, "100%":{opacity:1,transform:"translateY(0)"} }
       },
-      animation: {
-        floaty: "floaty 8s ease-in-out infinite",
-        fadeUp: "fadeUp .5s ease-out both",
-        pulseGlow: "pulseGlow 4s ease-in-out infinite"
-      }
+      animation: { floaty:"floaty 8s ease-in-out infinite", fadeUp:"fadeUp .5s ease-out both" }
     }
   },
   plugins: []


### PR DESCRIPTION
## Summary
- Neon-glass UI with Tailwind animations and skip link
- Markdown diary with encryption, tags, attachments, and search
- Command palette, settings panel, and GitHub Pages workflow with BASE_PATH

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ba2d6ff404832399171cf08cc9e900