### PR TITLE
Add emoji favicon to Design Playground

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <title>Design Playground</title>
   <meta name="color-scheme" content="dark light"/>
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E🎨%3C/text%3E%3C/svg%3E"/>
   <link rel="stylesheet" href="styles.css"/>
   <!-- html2canvas via CDN -->
   <script defer src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>


### PR DESCRIPTION
## Summary
- Add SVG data URI favicon with palette emoji for a custom tab icon
- Ignore node_modules to keep repository clean

## Testing
- ⚠️ `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68bb0783d3888323a948515a40dced61